### PR TITLE
chore: Add privacy manifest file.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,15 +30,27 @@ let package = Package(
             name: "BuildableMacros",
             dependencies: [
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
             ]
         ),
 
         // Library that exposes a macro as part of its API, which is used in client programs.
-        .target(name: "BuildableMacro", dependencies: ["BuildableMacros"]),
+        .target(
+            name: "BuildableMacro",
+            dependencies: ["BuildableMacros"],
+            resources: [
+                .process("../PrivacyInfo.xcprivacy"),
+            ]
+        ),
 
         // A client of the library, which is able to use the macro in its own code.
-        .executableTarget(name: "BuildableMacroClient", dependencies: ["BuildableMacro"]),
+        .executableTarget(
+            name: "BuildableMacroClient",
+            dependencies: ["BuildableMacro"],
+            resources: [
+                .process("../PrivacyInfo.xcprivacy"),
+            ]
+        ),
 
         // A test target used to develop the macro implementation.
         .testTarget(

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -30,15 +30,27 @@ let package = Package(
             name: "BuildableMacros",
             dependencies: [
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
             ]
         ),
 
         // Library that exposes a macro as part of its API, which is used in client programs.
-        .target(name: "BuildableMacro", dependencies: ["BuildableMacros"]),
+        .target(
+            name: "BuildableMacro",
+            dependencies: ["BuildableMacros"],
+            resources: [
+                .process("../PrivacyInfo.xcprivacy"),
+            ]
+        ),
 
         // A client of the library, which is able to use the macro in its own code.
-        .executableTarget(name: "BuildableMacroClient", dependencies: ["BuildableMacro"]),
+        .executableTarget(
+            name: "BuildableMacroClient",
+            dependencies: ["BuildableMacro"],
+            resources: [
+                .process("../PrivacyInfo.xcprivacy"),
+            ]
+        ),
 
         // A test target used to develop the macro implementation.
         .testTarget(

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
This merge request adds the privacy manifest file to the targets. 

I don't know if this is required for every package and specially this package is all about macros which is a compile-time feature. So I don't think that having privacy manifest even means anything.