### PR TITLE
fix: reversed order access controls

### DIFF
--- a/Tests/BuildableMacroTests/BuildableTrackedMacroTests.swift
+++ b/Tests/BuildableMacroTests/BuildableTrackedMacroTests.swift
@@ -333,7 +333,7 @@ final class BuildableTrackedMacroTests: XCTestCase {
                     copy.p1 = value
                     return copy
                 }
-                public private(set) var p2: String = ""
+                private(set) public var p2: String = ""
 
                 private func p2(_ value: String) -> Self {
                     var copy = self

--- a/Tests/BuildableMacroTests/BuildableTrackedMacroTests.swift
+++ b/Tests/BuildableMacroTests/BuildableTrackedMacroTests.swift
@@ -313,6 +313,38 @@ final class BuildableTrackedMacroTests: XCTestCase {
         }
     }
 
+    func testReversedOrderAccessControls() throws {
+        assertMacro {
+            """
+            public struct Sample {
+                @BuildableTracked
+                public private(set) var p1: String
+                @BuildableTracked
+                private(set) public var p2: String = ""
+            }
+            """
+        } expansion: {
+            """
+            public struct Sample {
+                public private(set) var p1: String
+
+                private func p1(_ value: String) -> Self {
+                    var copy = self
+                    copy.p1 = value
+                    return copy
+                }
+                public private(set) var p2: String = ""
+
+                private func p2(_ value: String) -> Self {
+                    var copy = self
+                    copy.p2 = value
+                    return copy
+                }
+            }
+            """
+        }
+    }
+
     func testFileprivateAccessControlSetters() throws {
         assertMacro {
             """


### PR DESCRIPTION
Turns out multiple access controls can produce undesired code. I have added a test that shows this. But this should be `green` first before we can merge this into the main branch.